### PR TITLE
Update zones for surf_kitsune & surf_ace to follow new trigger naming standards

### DIFF
--- a/scripts/wst_zones/surf_ace.txt
+++ b/scripts/wst_zones/surf_ace.txt
@@ -5,11 +5,11 @@
     {
         "start"
         {
-            "targetname" "1z"
+            "targetname" "s1_start"
         }
         "end"
         {
-            "targetname" "endm"
+            "targetname" "map_end"
         }
     }
 }

--- a/scripts/wst_zones/surf_kitsune.txt
+++ b/scripts/wst_zones/surf_kitsune.txt
@@ -5,11 +5,11 @@
     {
         "start"
         {
-            "targetname" "stage1_start"
+            "targetname" "s1_start"
         }
         "end"
         {
-            "targetname" "stage9_end"
+            "targetname" "map_end"
         }
     }
 }


### PR DESCRIPTION
The CS2 Surf initiative is updating ports to follow a standard zone trigger naming convention: https://github.com/CS2Surf/Timer/wiki/CS2-Surf-Mapping 

This PR updates the `surf_kitsune` and `surf_ace` to maintain compatibility.
- https://steamcommunity.com/sharedfiles/filedetails/?id=3076153623
- https://steamcommunity.com/sharedfiles/filedetails/?id=3088413071

(These two maps have already been updated, the others will be following shortly. An announcement about this will be in [the CS2 Surf Discord](https://discord.gg/uksurKNzt5))